### PR TITLE
Fix TwoCaptcha/check_hint_img method

### DIFF
--- a/twocaptcha/solver.py
+++ b/twocaptcha/solver.py
@@ -1021,6 +1021,7 @@ class TwoCaptcha():
             return params, files
 
         if not '.' in hint and len(hint) > 50:
+            params.update({'imginstructions': hint})
             return params, files
 
         if not os.path.exists(hint):


### PR DESCRIPTION
TwoCaptcha/check_hint_img method removed 'imginstructions' key from params if it was in base64